### PR TITLE
Better compatability with DecimalPercentages + one minor change

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,22 +1,20 @@
-set(GEODE_TARGET_PLATFORM "Win64")
-
 cmake_minimum_required(VERSION 3.21)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 if ("${CMAKE_SYSTEM_NAME}" STREQUAL "iOS" OR IOS)
-    set(CMAKE_OSX_ARCHITECTURES "arm64")
+	set(CMAKE_OSX_ARCHITECTURES "arm64")
 else()
-    set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64")
+	set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64")
 endif()
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 
 project(BetterPercentage VERSION 1.0.0)
 
-# Add all source files inside src (recursively)
-file(GLOB_RECURSE SOURCES CONFIGURE_DEPENDS src/*.cpp)
-
 # Set up the mod binary
-add_library(${PROJECT_NAME} SHARED ${SOURCES})
+add_library(${PROJECT_NAME} SHARED
+    src/main.cpp
+    # Add any extra C++ source files here
+)
 
 if (NOT DEFINED ENV{GEODE_SDK})
     message(FATAL_ERROR "Unable to find Geode SDK! Please define GEODE_SDK environment variable to point to Geode")

--- a/mod.json
+++ b/mod.json
@@ -15,13 +15,16 @@
 		"gameplay",
 		"enhancement"
 	],
-
+	"dependencies": {
+		"cvolton.level-id-api": ">=v1.0.1"
+	},
 	"settings": {
 		"decimals": {
 			"name": "Decimals",
 			"description": "Amount of decimal places on the percentage",
 			"type": "int",
-			"default": 2
+			"default": 2,
+			"min": 0
 		},
 		"show-percent-symbol": {
 			"name": "Show Percent Symbol",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,7 +17,7 @@ class $modify(MyPlayLayer, PlayLayer) {
 
 	std::string getDPSavedValueKey(GJGameLevel* level) {
 		if (!level) return "";
-		practice = m_isPracticeMode;
+		bool practice = m_isPracticeMode;
 		if (level->m_levelType == GJLevelType::Editor)
 			return fmt::format("percentage_{}_local_{}", practice ? "practice" : "normal", EditorIDs::getID(level));
 		if (level->m_gauntletLevel)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,4 @@
-#include <Geode/Geode.hpp>
+#include <cvolton.level-id-api/include/EditorIDs.hpp>
 #include <Geode/modify/PlayLayer.hpp>
 
 using namespace geode::prelude;
@@ -6,12 +6,41 @@ using namespace geode::prelude;
 //TODO: add realtime new best option maybe idk
 // also change best on level beat or something idk
 
-class $modify(PlayLayer) {
+class $modify(MyPlayLayer, PlayLayer) {
 	struct Fields {
 		float m_runFrom;
 		float m_bestRunEnd;
 		std::unordered_map<double, double> m_bestRunEnds;	// dumb name i think idk
+		Mod* m_decimalPercentages = nullptr;
+		float m_decimalPercentagesPercent = 0.f;
 	};
+
+	std::string getDPSavedValueKey(GJGameLevel* level) {
+		if (!level) return "";
+		if (level->m_levelType == GJLevelType::Editor)
+			return fmt::format("percentage_{}_local_{}", practice ? "practice" : "normal", EditorIDs::getID(level));
+		if (level->m_gauntletLevel)
+			return fmt::format("percentage_{}_gauntlet_{}", practice ? "practice" : "normal", level->m_levelID.value());
+		if (level->m_dailyID.value() == 0)
+			return fmt::format("percentage_{}_{}", practice ? "practice" : "normal", level->m_levelID.value());
+		return fmt::format("percentage_{}_{}_periodic_{}", practice ? "practice" : "normal", level->m_levelID.value(), level->m_dailyID.value());
+	}
+
+	void setupHasCompleted() {
+		PlayLayer::setupHasCompleted();
+		auto level = m_level;
+
+		bool hasDecimalPercentages = Loader::get()->isModLoaded("raydeeux_thesillydoggo.decimalpercentages");
+		if (!hasDecimalPercentages || !level) return;
+
+		m_fields->m_decimalPercentages = Loader::get()->getLoadedMod("raydeeux_thesillydoggo.decimalpercentages");
+		if (!m_fields->m_decimalPercentages) return;
+
+		std::string savedValueKey = MyPlayLayer::getDPSavedValueKey(level);
+		if (!m_fields->m_decimalPercentages->hasSavedValue<float>(savedValueKey)) return;
+
+		m_fields->m_decimalPercentagesPercent = m_fields->m_decimalPercentages->getSavedValue<float>(savedValueKey);
+	}
 
 	void destroyPlayer(PlayerObject* player, GameObject* object) {
 		PlayLayer::destroyPlayer(player, object);
@@ -36,6 +65,12 @@ class $modify(PlayLayer) {
 			[](auto, bool btn2) {
 			}
 		);*/
+		if (!m_fields->m_decimalPercentages || !m_level) return;
+
+		std::string savedValueKey = MyPlayLayer::getDPSavedValueKey(m_level);
+		if (!m_fields->m_decimalPercentages->hasSavedValue<float>(savedValueKey)) return;
+
+		m_fields->m_decimalPercentagesPercent = m_fields->m_decimalPercentages->getSavedValue<float>(savedValueKey);
 	}
 
 	void updateProgressbar() {
@@ -52,9 +87,7 @@ class $modify(PlayLayer) {
 		auto showLevelBestFromZero = Mod::get()->getSettingValue<bool>("show-level-best-from-zero");
 
 		auto formatNumber = [decimals](double value) {
-			std::ostringstream ostringstream;
-			ostringstream << std::fixed << std::setprecision(decimals) << value;
-			return ostringstream.str();
+			return fmt::format("{:.{}f}", value, decimals);
 		};
 
 		auto runFrom = (showRunFrom)
@@ -64,11 +97,17 @@ class $modify(PlayLayer) {
 			)
 			: "";
 
+		auto normalPercentAsString = geode::utils::numToString(m_level->m_normalPercent);
+
+		if (m_fields->hasDecimalPercentages) {
+			normalPercentAsString = geode::utils::numToString(m_fields->m_decimalPercentagesPercent);
+		}
+
 		auto bestRun = (showBestRun && !(m_fields->m_runFrom == 0 && hideBestRunFromZero))
 			? ((m_fields->m_runFrom == 0 && showLevelBestFromZero)
-				? "/" + std::to_string(m_level->m_normalPercent)
+				? " / " + normalPercentAsString
 				: ((m_fields->m_bestRunEnds.count(m_fields->m_runFrom))
-			 		? "/" + formatNumber(m_fields->m_bestRunEnds[m_fields->m_runFrom])	// wtf is this
+			 		? " / " + formatNumber(m_fields->m_bestRunEnds[m_fields->m_runFrom])	// wtf is this
 					: ""
 				)
 	  		)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -99,7 +99,7 @@ class $modify(MyPlayLayer, PlayLayer) {
 
 		auto normalPercentAsString = geode::utils::numToString(m_level->m_normalPercent);
 
-		if (m_fields->hasDecimalPercentages) {
+		if (m_fields->m_decimalPercentages) {
 			normalPercentAsString = geode::utils::numToString(m_fields->m_decimalPercentagesPercent);
 		}
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,7 +37,7 @@ class $modify(MyPlayLayer, PlayLayer) {
 		if (!m_fields->m_decimalPercentages) return;
 
 		std::string savedValueKey = MyPlayLayer::getDPSavedValueKey(level);
-		if (!m_fields->m_decimalPercentages->hasSavedValue<float>(savedValueKey)) return;
+		if (!m_fields->m_decimalPercentages->hasSavedValue(savedValueKey)) return;
 
 		m_fields->m_decimalPercentagesPercent = m_fields->m_decimalPercentages->getSavedValue<float>(savedValueKey);
 	}
@@ -68,7 +68,7 @@ class $modify(MyPlayLayer, PlayLayer) {
 		if (!m_fields->m_decimalPercentages || !m_level) return;
 
 		std::string savedValueKey = MyPlayLayer::getDPSavedValueKey(m_level);
-		if (!m_fields->m_decimalPercentages->hasSavedValue<float>(savedValueKey)) return;
+		if (!m_fields->m_decimalPercentages->hasSavedValue(savedValueKey)) return;
 
 		m_fields->m_decimalPercentagesPercent = m_fields->m_decimalPercentages->getSavedValue<float>(savedValueKey);
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,7 @@ class $modify(MyPlayLayer, PlayLayer) {
 
 	std::string getDPSavedValueKey(GJGameLevel* level) {
 		if (!level) return "";
+		practice = m_isPracticeMode;
 		if (level->m_levelType == GJLevelType::Editor)
 			return fmt::format("percentage_{}_local_{}", practice ? "practice" : "normal", EditorIDs::getID(level));
 		if (level->m_gauntletLevel)


### PR DESCRIPTION
there's a feature in both QOLMod and YetAnotherModMenu (which i developed) that shows the best percentage in the percentage label, which DecimalPercentages (which i also developed) then replaces with a percentage that has more decimal points.

seeing as this mod overwrites the entirety of the percentage label, i decided to have this mod fetch the percentage saved from DecimalPercentages as a workaround for compatability.

also added an extra space for the `/` in the percentage label to make things easier to read from a distance